### PR TITLE
Added support for Access Tokens and improved message conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ touch .env
 
 ```sh
 NTFY_WS = "ntfy.sh/"
+NTFY_ACCESS_CONTROL = "<ACCESS TOKEN>" # This field is optional, only there in case you need to use some authentication. You will need to generate an access token as explained here: https://docs.ntfy.sh/publish/#access-tokens
 NTFY_TOPIC ="<YOUR TOPIC>"
 TELEGRAM_BOT = "https://api.telegram.org/bot<YOUR BOT API TOKEN>/sendMessage"
 TELEGRAM_ID = "<CHAT ID>"
@@ -54,6 +55,7 @@ RUN pip install --upgrade pip
 RUN pip3 install requests python-dotenv websocket-client
 ENV NTFY_WS = "ntfy.sh/"
 ENV NTFY_TOPIC ="<YOUR TOPIC>"
+ENV NTFY_ACCESS_CONTROL = "<ACCESS TOKEN>"
 ENV TELEGRAM_BOT = "https://api.telegram.org/bot<YOUR BOT API TOKEN>/sendMessage"
 ENV TELEGRAM_ID = "<CHAT ID>"
 COPY ntfy.py /usr/bin

--- a/ntfy.py
+++ b/ntfy.py
@@ -14,11 +14,21 @@ chat_id = os.environ["TELEGRAM_ID"]
 
 def on_message(ws, message):
     msg = json.loads(message)
-    if not 'title' in msg or len(msg['title']) == 0:
+    if not msg.get('title', '').strip() and not msg.get('message', '').strip():
        print('\n >>> Ntfy.sh websocket Successfully Passing...! \n')
     else:
+        # Only add the title and \n\n if there is a non-empty title key
+        text_content = ''
+        if msg.get('title', '').strip():
+            text_content += '**' + msg['title'].strip() + '**\n\n'
+        text_content += msg.get('message', '').strip()  # Add the message, if any
+        
         headers = {"content-type": "application/x-www-form-urlencoded"}
-        querystring = {"chat_id": chat_id, "text": msg['title'] + "\n\n" +  msg['message']}
+        querystring = {
+            "chat_id": chat_id,
+            "text": text_content,
+            "parse_mode": "Markdown"  # Enable Markdown formatting
+        }
         response = requests.request(
                 "POST", telegram_bot, headers=headers, params=querystring)
         print("websocket: " + message + "Ntfy: " + response.text)

--- a/ntfy.py
+++ b/ntfy.py
@@ -35,7 +35,7 @@ def on_open(ws):
 if __name__ == "__main__":
     headers = []
     if ntfy_access_control:  # Add the header only if ntfy_access_control is defined and not empty
-        headers.append("Authorization: Basic " + str(ntfy_access_control))
+        headers.append("Authorization: Bearer " + str(ntfy_access_control))
 
     wsapp = websocket.WebSocketApp("wss://" + str(ntfy_ws) + ntfy_topic + "/ws",
                                    on_open=on_open,

--- a/ntfy.py
+++ b/ntfy.py
@@ -7,6 +7,7 @@ import requests
 load_dotenv()
 
 ntfy_ws = os.environ["NTFY_WS"]
+ntfy_access_control = os.environ.get("NTFY_ACCESS_CONTROL")  # Use .get to handle if not defined
 ntfy_topic = os.environ["NTFY_TOPIC"]
 telegram_bot = os.environ["TELEGRAM_BOT"]
 chat_id = os.environ["TELEGRAM_ID"]
@@ -32,9 +33,14 @@ def on_open(ws):
     print("\n >> Opened NTFY websocket connection..! \n")
 
 if __name__ == "__main__":
+    headers = []
+    if ntfy_access_control:  # Add the header only if ntfy_access_control is defined and not empty
+        headers.append("Authorization: Basic " + str(ntfy_access_control))
+
     wsapp = websocket.WebSocketApp("wss://" + str(ntfy_ws) + ntfy_topic + "/ws",
                                    on_open=on_open,
                                    on_message=on_message,
                                    on_error=on_error,
-                                   on_close=on_close)
+                                   on_close=on_close,
+                                   header=headers)  # headers is now conditionally populated
     wsapp.run_forever()

--- a/ntfy.py
+++ b/ntfy.py
@@ -20,14 +20,14 @@ def on_message(ws, message):
         # Only add the title and \n\n if there is a non-empty title key
         text_content = ''
         if msg.get('title', '').strip():
-            text_content += '**' + msg['title'].strip() + '**\n\n'
+            text_content += '*' + msg['title'].strip() + '*\n\n'
         text_content += msg.get('message', '').strip()  # Add the message, if any
         
         headers = {"content-type": "application/x-www-form-urlencoded"}
         querystring = {
             "chat_id": chat_id,
             "text": text_content,
-            "parse_mode": "Markdown"  # Enable Markdown formatting
+            "parse_mode": "MarkdownV2"  # Enable Markdown formatting
         }
         response = requests.request(
                 "POST", telegram_bot, headers=headers, params=querystring)


### PR DESCRIPTION
First of all, thanks for building this, this was a really useful starting tool for integrating Ntfy into my system.

I needed a few changes and I wanted to share them in case it is useful for others. I added the following:
- Support for access tokens. In case you have a secured Ntfy server, you might need to use it. You can now set the env var called `NTFY_ACCESS_CONTROL` with an access token you created (without the `Bearer ` string), as explained here: https://docs.ntfy.sh/publish/#access-tokens If you are not in need of access tokens, you can just leave this var unset.
- I had an issue where I needed to send a message without a title. So I modified the conditions so it ignores the message if there is no title and no message or both are empty strings. I also made it so that if there is a title, we send the title section of the message in bold, using MarkdownV2.